### PR TITLE
Fix undefined angle in robot initialization

### DIFF
--- a/src/components/RoombaSimulation.tsx
+++ b/src/components/RoombaSimulation.tsx
@@ -148,7 +148,7 @@ export default function RoombaSimulation() {
         y,
         vx: 0,
         vy: 0,
-        angle: angle + Math.PI,
+        angle: Math.random() * Math.PI * 2,
         targetAngle: 0,
         path: [],
         scanAngle: 0,


### PR DESCRIPTION
## Summary
- Initialize each robot with a random heading instead of referencing an undefined angle

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` and `Orbitron` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68973f11a4a08329b9c268ecf13df1a2