### PR TITLE
Refresh UI with lighter theme

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -42,7 +42,7 @@ const ContactPage = () => {
         <button
           type="submit"
           disabled={status === "sending"}
-          className="rounded-md bg-gray-900 text-white px-4 py-2 hover:bg-gray-700 disabled:opacity-50"
+          className="rounded-md bg-blue-600 text-white px-4 py-2 hover:bg-blue-500 disabled:opacity-50"
         >
           {status === "sending" ? "Sending..." : "Send"}
         </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f8fafc;
+  --foreground: #1a202c;
 }
 
 @theme inline {
@@ -10,13 +10,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
       <div className="flex flex-wrap justify-center gap-3">
         <Link
           href="/projects"
-          className="rounded-md bg-gray-900 text-white px-4 py-2 hover:bg-gray-700"
+          className="rounded-md bg-blue-600 text-white px-4 py-2 hover:bg-blue-500"
         >
           View Projects
         </Link>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import { siteConfig } from "@/data/site";
 
 const Footer = () => {
   return (
-    <footer className="bg-gray-800 text-white p-4 mt-8">
+    <footer className="bg-white text-gray-700 p-4 mt-8 border-t">
       <div className="container mx-auto text-center">
         <p className="space-x-3">
           <span>
@@ -12,7 +12,7 @@ const Footer = () => {
             href={siteConfig.links.linkedin}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline hover:text-gray-300"
+            className="underline hover:text-blue-600"
           >
             LinkedIn
           </a>
@@ -20,7 +20,7 @@ const Footer = () => {
             href={siteConfig.links.github}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline hover:text-gray-300"
+            className="underline hover:text-blue-600"
           >
             GitHub
           </a>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,12 +7,12 @@ const Navbar = () => {
   const pathname = usePathname();
 
   const navItemClass = (href: string) =>
-    `hover:text-gray-300 ${pathname === href ? "text-gray-300 underline" : ""}`;
+    `${pathname === href ? "text-blue-600 underline" : "text-gray-600"} hover:text-gray-800`;
 
   return (
-    <nav className="bg-gray-800 text-white p-4">
+    <nav className="bg-white text-gray-800 shadow p-4">
       <div className="container mx-auto flex justify-between items-center">
-        <Link href="/" className="text-2xl font-bold">
+        <Link href="/" className="text-2xl font-bold text-gray-900">
           {siteConfig.name}
         </Link>
         <ul className="flex space-x-4">

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -23,7 +23,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ name, description, imageUrl, 
           height={480}
           className="h-auto w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
         />
-        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-black/10 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-white/70 via-white/30 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
       </div>
       <div className="p-4">
         <h3 className="text-xl font-bold mb-2">{name}</h3>

--- a/src/components/RoombaSimulation.tsx
+++ b/src/components/RoombaSimulation.tsx
@@ -837,17 +837,17 @@ export default function RoombaSimulation() {
 
   return (
     <>
-      <canvas 
-        ref={canvasRef} 
-        className="fixed inset-0 pointer-events-none opacity-70 -z-10" 
-        style={{ background: "linear-gradient(135deg, #0a0a0f, #0f0f1a)" }}
+      <canvas
+        ref={canvasRef}
+        className="fixed inset-0 pointer-events-none opacity-40 -z-10"
+        style={{ background: "linear-gradient(135deg, #ffffff, #e3f2fd)" }}
       />
-      <div 
+      <div
         ref={telemetryRef}
-        className="fixed top-4 left-4 bg-black/80 backdrop-blur-sm border border-cyan-600/30 rounded-lg p-4 pointer-events-none z-50"
+        className="fixed top-4 left-4 bg-white/80 text-gray-800 backdrop-blur-sm border border-cyan-600/30 rounded-lg p-4 pointer-events-none z-50"
         style={{ minWidth: "320px" }}
       />
-      <div className="fixed bottom-4 left-4 font-mono text-xs text-cyan-400/60 pointer-events-none z-50">
+      <div className="fixed bottom-4 left-4 font-mono text-xs text-cyan-700/70 pointer-events-none z-50">
         <div>GLOBAL ROBOTICS NETWORK v2.0</div>
         <div>Click robot for telemetry</div>
         <div>{NUM_ROBOTS} agents | {MAJOR_CITIES.length} nodes</div>


### PR DESCRIPTION
## Summary
- Switch global styling to a light colour palette
- Rework navigation, footer, and action buttons for a cleaner card-based look
- Soften simulation and project card visuals for a brighter feel

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter`/`Orbitron` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6897446420b88329b3a02e646f5fe2ae