### PR TITLE
Add experience page and refresh portfolio content

### DIFF
--- a/public/logos/appliedmaterials.svg
+++ b/public/logos/appliedmaterials.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#e0f2fe"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#0c4a6e" font-family="Arial">AM</text>
+</svg>

--- a/public/logos/designvisionaries.svg
+++ b/public/logos/designvisionaries.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#f3f4f6"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#111827" font-family="Arial">DV</text>
+</svg>

--- a/public/logos/saildrone.svg
+++ b/public/logos/saildrone.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#ffedd5"/>
+  <text x="50" y="55" font-size="32" text-anchor="middle" fill="#c2410c" font-family="Arial">SD</text>
+</svg>

--- a/public/logos/velodyne.svg
+++ b/public/logos/velodyne.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eef2ff"/>
+  <text x="50" y="55" font-size="32" text-anchor="middle" fill="#1e3a8a" font-family="Arial">VL</text>
+</svg>

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -1,0 +1,17 @@
+import ExperienceCard from "@/components/ExperienceCard";
+import { experiences } from "@/data/experience";
+
+const ExperiencePage = () => {
+  return (
+    <section>
+      <h1 className="text-3xl font-bold mb-8">Experience</h1>
+      <div className="flex flex-col gap-6">
+        {experiences.map((exp) => (
+          <ExperienceCard key={exp.company + exp.role} {...exp} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ExperiencePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,11 +22,14 @@ export default function Home() {
       <p className="max-w-2xl text-gray-700">
         <Typewriter
           phrases={[
-            "I build robots that don’t bump into chairs.",
-            "Sometimes they do. We fix it with math.",
-            "Mapping, perception, control—preferably in real-time.",
+            "The gap between prototype and product? I live there.",
+            "From self-driving to med-tech, I ship reliable systems.",
+            "I optimize, reduce costs, and deliver hardware at scale.",
           ]}
         />
+      </p>
+      <p className="max-w-3xl text-gray-700">
+        As both a hands-on engineer and project manager, I turn complex concepts in self-driving and med-tech into reliable, deployed systems. I optimize, reduce costs, and ship products for companies like Meta, Applied Materials, Google, GoPro, Saildrone, Velodyne Lidar, Hummingbird EV, Tesla, and more than twenty startups and researchers. As an NSF-trained pedagogy professional, I also teach how to teach.
       </p>
       <div className="flex flex-wrap justify-center gap-3">
         <Link

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+
+interface ExperienceCardProps {
+  company: string;
+  role: string;
+  period: string;
+  location: string;
+  description: string;
+  imageUrl: string;
+}
+
+const ExperienceCard = ({ company, role, period, location, description, imageUrl }: ExperienceCardProps) => {
+  return (
+    <div className="flex gap-4 p-4 border rounded-md bg-white shadow-sm">
+      <Image src={imageUrl} alt={company} width={64} height={64} className="rounded-md object-contain" />
+      <div>
+        <h3 className="text-xl font-semibold">{role}</h3>
+        <p className="text-gray-600">{company} • {period}</p>
+        <p className="text-gray-600 italic">{location}</p>
+        <p className="mt-2 text-gray-700">{description}</p>
+      </div>
+    </div>
+  );
+};
+
+export default ExperienceCard;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,6 +25,11 @@ const Navbar = () => {
             </Link>
           </li>
           <li>
+            <Link href="/experience" className={navItemClass("/experience")}>
+              Experience
+            </Link>
+          </li>
+          <li>
             <Link href="/skills" className={navItemClass("/skills")}>Skills</Link>
           </li>
           <li>

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,0 +1,39 @@
+export const experiences = [
+  {
+    company: "Design Visionaries",
+    role: "Project Manager - Mechatronics",
+    period: "Apr 2023 - Present",
+    location: "San Jose, CA",
+    imageUrl: "/logos/designvisionaries.svg",
+    description:
+      "Turned napkin sketches into profitable hardware, delivering $300k+ projects for Tesla, Apple, Meta, Applied Materials, and Saildrone. Led embedded systems for 5+ stealth startups.",
+  },
+  {
+    company: "Applied Materials",
+    role: "Manufacturing Engineer",
+    period: "Sep 2024 - Feb 2025",
+    location: "Santa Clara County, CA",
+    imageUrl: "/logos/appliedmaterials.svg",
+    description: "Implemented GD&T for Cold Plasma ALD systems.",
+  },
+  {
+    company: "Saildrone",
+    role: "Engineering Consultant",
+    period: "Apr 2023 - Jan 2024",
+    location: "Alameda, CA",
+    imageUrl: "/logos/saildrone.svg",
+    description:
+      "Managed harness production for autonomous sailing drones and streamlined inventory and training.",
+  },
+  {
+    company: "Velodyne Lidar",
+    role: "Senior Robotics Engineer",
+    period: "Jan 2021 - Sep 2022",
+    location: "California, USA",
+    imageUrl: "/logos/velodyne.svg",
+    description:
+      "Developed proof-of-concept robotic platforms and sensor rigs, maintaining research fleets and writing sensor fusion APIs.",
+  },
+] as const;
+
+export type Experience = typeof experiences[number];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,9 +1,9 @@
 export const siteConfig = {
   name: "Shivam Bhardwaj",
-  role: "Robotics Engineer",
-  email: "your.email@example.com",
-  location: "California",
-  currentCompany: "AntiMony Group",
+  role: "Project Manager & Robotics Engineer",
+  email: "contact@shivambhardwaj.com",
+  location: "San Jose, CA",
+  currentCompany: "Design Visionaries",
   links: {
     github: "https://github.com/Shivam-Bhardwaj",
     linkedin: "https://www.linkedin.com/in/shivambdj/",


### PR DESCRIPTION
## Summary
- update homepage with new tagline and bio reflecting recent projects and clients
- add experience section with company logos and detailed descriptions
- include experience link in navigation and refresh site contact info

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689757290df083298afc1b32861a2188