### PR TITLE
Add interactive swarm robotics game

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,12 @@ export default function Home() {
         >
           My Skills
         </Link>
+        <Link
+          href="/swarm"
+          className="rounded-md border border-gray-300 px-4 py-2 hover:bg-gray-50"
+        >
+          Play Swarm Game
+        </Link>
         <a
           href={siteConfig.links.github}
           target="_blank"

--- a/src/app/swarm/page.tsx
+++ b/src/app/swarm/page.tsx
@@ -1,0 +1,19 @@
+import SwarmGame from "@/components/SwarmGame";
+
+export const metadata = {
+  title: "Swarm Game",
+};
+
+export default function SwarmPage() {
+  return (
+    <section className="p-6 flex flex-col items-center gap-4">
+      <h1 className="text-3xl font-bold">Swarm Robotics Game</h1>
+      <p className="text-gray-700 text-center max-w-2xl">
+        Drop targets for a team of simple robots and watch how the swarm cooperates
+        to collect them before the timer runs out.
+      </p>
+      <SwarmGame />
+    </section>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,10 @@ const Navbar = () => {
             <Link href="/skills" className={navItemClass("/skills")}>Skills</Link>
           </li>
           <li>
-            <Link href="/contact" className={navItemClass("/contact")}>
+            <Link href="/swarm" className={navItemClass("/swarm")}>Swarm Game</Link>
+          </li>
+          <li>
+            <Link href="/contact" className={navItemClass("/contact")}> 
               Contact
             </Link>
           </li>

--- a/src/components/SwarmGame.tsx
+++ b/src/components/SwarmGame.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+interface Robot {
+  x: number;
+  y: number;
+  angle: number;
+}
+
+interface Target {
+  x: number;
+  y: number;
+}
+
+const NUM_ROBOTS = 20;
+const ROBOT_SPEED = 1.5;
+const ROBOT_RADIUS = 5;
+const TARGET_RADIUS = 10;
+
+export default function SwarmGame() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const robotsRef = useRef<Robot[]>([]);
+  const targetsRef = useRef<Target[]>([]);
+  const [score, setScore] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(60);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    canvas.width = window.innerWidth;
+    canvas.height = 500;
+
+    robotsRef.current = Array.from({ length: NUM_ROBOTS }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      angle: Math.random() * Math.PI * 2,
+    }));
+
+    const handleClick = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      targetsRef.current.push({
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top,
+      });
+    };
+    canvas.addEventListener("click", handleClick);
+
+    const update = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = "gold";
+      targetsRef.current.forEach((t) => {
+        ctx.beginPath();
+        ctx.arc(t.x, t.y, TARGET_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      robotsRef.current.forEach((r) => {
+        if (targetsRef.current.length > 0) {
+          const target = targetsRef.current.reduce((prev, cur) => {
+            const prevDist = Math.hypot(prev.x - r.x, prev.y - r.y);
+            const curDist = Math.hypot(cur.x - r.x, cur.y - r.y);
+            return curDist < prevDist ? cur : prev;
+          }, targetsRef.current[0]);
+          const angle = Math.atan2(target.y - r.y, target.x - r.x);
+          r.x += Math.cos(angle) * ROBOT_SPEED;
+          r.y += Math.sin(angle) * ROBOT_SPEED;
+          if (Math.hypot(target.x - r.x, target.y - r.y) < TARGET_RADIUS) {
+            targetsRef.current = targetsRef.current.filter((t) => t !== target);
+            setScore((s) => s + 1);
+          }
+        } else {
+          r.x += Math.cos(r.angle) * ROBOT_SPEED;
+          r.y += Math.sin(r.angle) * ROBOT_SPEED;
+        }
+        if (r.x < 0 || r.x > canvas.width) r.angle = Math.PI - r.angle;
+        if (r.y < 0 || r.y > canvas.height) r.angle = -r.angle;
+
+        ctx.fillStyle = "teal";
+        ctx.beginPath();
+        ctx.arc(r.x, r.y, ROBOT_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      animationRef.current = requestAnimationFrame(update);
+    };
+
+    const animationRef = { current: 0 };
+    update();
+
+    const timer = setInterval(() => {
+      setTimeLeft((t) => {
+        if (t <= 1) {
+          cancelAnimationFrame(animationRef.current);
+          clearInterval(timer);
+          return 0;
+        }
+        return t - 1;
+      });
+    }, 1000);
+
+    return () => {
+      canvas.removeEventListener("click", handleClick);
+      cancelAnimationFrame(animationRef.current);
+      clearInterval(timer);
+    };
+  }, []);
+
+  return (
+    <div className="relative">
+      <canvas ref={canvasRef} className="w-full border border-gray-300" />
+      <div className="absolute top-2 left-2 rounded bg-white/80 px-2 py-1 text-sm">
+        Score: {score} • Time: {timeLeft}
+      </div>
+      <p className="mt-2 text-sm text-gray-700">
+        Click inside the arena to drop targets for the robots to collect.
+      </p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add SwarmGame canvas component with score and timer
- New /swarm page to showcase swarm robotics gameplay
- Link Swarm Game from navbar and home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897633eb1e0832991a4f2a6716ff80e