### PR TITLE
Fix missing refs in RoombaSimulation

### DIFF
--- a/src/components/RoombaSimulation.tsx
+++ b/src/components/RoombaSimulation.tsx
@@ -97,6 +97,18 @@ export default function RoombaSimulation() {
   const [highScore, setHighScore] = useState(0);
   const highScoreRef = useRef(0);
   const totalCellsRef = useRef(0);
+  const exploredCellsRef = useRef(0);
+  const startTimeRef = useRef(0);
+  const bestTimeRef = useRef<number | null>(null);
+  const [gameStats, setGameStats] = useState<{
+    coverage: number;
+    time: number;
+    best: number | null;
+  }>({
+    coverage: 0,
+    time: 0,
+    best: null,
+  });
 
   useEffect(() => {
     const stored = Number(localStorage.getItem("roombaHighScore") || 0);

--- a/src/components/SwarmGame.tsx
+++ b/src/components/SwarmGame.tsx
@@ -19,7 +19,7 @@ export default function SwarmGame() {
   const robotsRef = useRef<Robot[]>([]);
 
   const targetRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
-  const animationRef = useRef<number>();
+  const animationRef = useRef<number | null>(null);
   const runningRef = useRef(false);
   const startRef = useRef(0);
   const [time, setTime] = useState(0);


### PR DESCRIPTION
## Summary
- add missing refs and game statistics state to RoombaSimulation
- initialize timing and tracking values to prevent compile errors

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` and `Orbitron` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6897f8639f1c8329b275045faf4c2a2f