### PR TITLE
Fix: Improve font color contrast in several components

### DIFF
--- a/src/app/styleguide/page.tsx
+++ b/src/app/styleguide/page.tsx
@@ -15,10 +15,10 @@ export default function StyleGuide() {
       <div className="container mx-auto px-4 py-12">
         {/* Header */}
         <motion.div variants={fadeIn} className="text-center mb-16">
-          <h1 className="text-display-lg text-gradient font-robotics mb-4">
+          <h1 className="text-display-lg text-gradient font-robotics mb-4 text-foreground">
             Design System
           </h1>
-          <p className="text-xl text-foreground-secondary max-w-3xl mx-auto">
+          <p className="text-xl text-foreground-secondary max-w-3xl mx-auto text-foreground">
             A comprehensive design system for the robotics portfolio, featuring modern components, 
             animations, and accessibility-first design principles.
           </p>

--- a/src/components/RoombaSimulation.tsx
+++ b/src/components/RoombaSimulation.tsx
@@ -1280,7 +1280,7 @@ export default function RoombaSimulation() {
       
       telemetryRef.current.innerHTML = `
         <div class="font-mono text-xs text-cyan-400">
-          <div class="mb-2 text-sm font-bold text-white">ROBOT ${robot.id} [${robot.role.toUpperCase()}]</div>
+          <div class="mb-2 text-sm font-bold text-gray-900">ROBOT ${robot.id} [${robot.role.toUpperCase()}]</div>
           <div class="grid grid-cols-2 gap-x-4 gap-y-1">
             <div>POS: (${robot.pose.x.toFixed(0)}, ${robot.pose.y.toFixed(0)})</div>
             <div>VEL: ${Math.sqrt(robot.vx**2 + robot.vy**2).toFixed(2)} m/s</div>


### PR DESCRIPTION
This commit addresses an issue where white or light-colored text was used on a light background, making it difficult to read.

The following changes have been made:

1.  In `src/components/RoombaSimulation.tsx`, the robot title in the telemetry display has been changed from `text-white` to `text-gray-900` to ensure it is readable against its light, semi-transparent background.
2.  In `src/app/styleguide/page.tsx`, the main title and description have been updated to use the `text-foreground` color to ensure they have proper contrast.

A broad search was conducted to find other instances of this issue, including searching for light color utility classes and investigating the usage of components with light backgrounds. While the most apparent issues have been fixed, the original request was general, so other minor instances might still exist.